### PR TITLE
Fixed shell command parsing

### DIFF
--- a/src/bob/util.clj
+++ b/src/bob/util.clj
@@ -76,7 +76,7 @@
                                           (recur (rest cmd) escaped? :normal current-arg args)
                                           (recur (rest cmd) escaped? state (str current-arg char) args))
                           :double-quote (case char
-                                          \" (recur cmd escaped? :normal current-arg args)
+                                          \" (recur (rest cmd) escaped? :normal current-arg args)
                                           \\ (let [next (second cmd)]
                                                (if (or (= next \")
                                                        (= next \\))

--- a/test/bob/util_test.clj
+++ b/test/bob/util_test.clj
@@ -62,3 +62,8 @@
   (testing "tokenizing a Shell command"
     (is (= (sh-tokenize! "sh -c \"while sleep 1; do echo ${RANDOM}; done\"")
            ["sh" "-c" "while sleep 1; do echo ${RANDOM}; done"]))))
+
+(deftest shell-arg-tokenize-test
+  (testing "tokenizing a Shell command with double quote message in the middle of the command"
+    (is (= (sh-tokenize! "sort -t \"\t\" -k2 test > test-sorted")
+           ["sort" "-t" "\t" "-k2" "test" ">" "test-sorted"]))))


### PR DESCRIPTION
Basically when tokenizer meets second double quote it switches to state `:normal` without removing it. In the next iteration command still has double quote but its treated as a new quote.

Issue: https://github.com/bob-cd/bob/issues/5