### PR TITLE
Fixing inconsistent response of pipeline list endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ strest_history.json
 kind
 .kube
 .#*
+bob-tests-local.strest.yaml
+docker-compose-local.yaml

--- a/integration-tests/bob-tests.strest.yaml
+++ b/integration-tests/bob-tests.strest.yaml
@@ -347,11 +347,11 @@ requests:
     validate:
       - jsonpath: "status"
         expect: 200
-      - jsonpath: "content[0].name"
+      - jsonpath: "content.message[0].name"
         expect: "dev:test"
-      - jsonpath: "content[1].name"
+      - jsonpath: "content.message[1].name"
         expect: "dev:test1"
-      - jsonpath: "content[2].name"
+      - jsonpath: "content.message[2].name"
         expect: "dev:this-fails"
 
   getPipelinesByStatus:
@@ -361,7 +361,7 @@ requests:
     validate:
       - jsonpath: "status"
         expect: 200
-      - jsonpath: "content[0].name"
+      - jsonpath: "content.message[0].name"
         expect: "dev:this-fails"
 
   getPipelinesByGroupAndName:
@@ -371,7 +371,7 @@ requests:
     validate:
       - jsonpath: "status"
         expect: 200
-      - jsonpath: "content[0].name"
+      - jsonpath: "content.message[0].name"
         expect: "dev:test"
 
   pipelineArtifacts:

--- a/src/bob/api/schemas.clj
+++ b/src/bob/api/schemas.clj
@@ -39,9 +39,9 @@
                        (s/optional-key :vars)      {Keyword String}
                        (s/optional-key :resources) [Resource]})
 
-(s/defschema PipelinesResponse (s/either {:message String}
-                                         [{:name   String
-                                           :data   Pipeline}]))
+(s/defschema PipelinesResponse (s/either {:message [String]}
+                                         {:message [{:name   String
+                                                     :data   Pipeline}]}))
 
 (s/defschema LogsResponse (s/either {:message [String]}
                                     SimpleResponse))

--- a/test/bob/pipeline/core_test.clj
+++ b/test/bob/pipeline/core_test.clj
@@ -304,7 +304,7 @@
                   :body
                   :message))))))
 
-(deftest get-pipeleines
+(deftest test-get-pipelines
   (testing "Filter pipelines"
     (with-redefs-fn {#'db/get-pipelines          (fn [_ filter]
                                                    (tu/check-and-fail
@@ -345,25 +345,27 @@
                                                      :pipeline "test:Test"}])}
       #(is (= [{:name "test:Test",
                 :data
-                      {:image     "test 1.7",
-                       :steps
-                                  [{:cmd "echo hello",
-                                    :produces_artifact
-                                         {:name "afile", :path "test.txt", :store "local"}}
-                                   {:cmd "mkdir"}],
-                       :resources [{:name     "src"
-                                    :type     nil
-                                    :provider "git"
-                                    :params   {:env "dev"}}]}}]
+                {:image     "test 1.7",
+                 :steps
+                 [{:cmd "echo hello",
+                   :produces_artifact
+                   {:name "afile", :path "test.txt", :store "local"}}
+                  {:cmd "mkdir"}],
+                 :resources [{:name     "src"
+                              :type     nil
+                              :provider "git"
+                              :params   {:env "dev"}}]}}]
               (-> @(get-pipelines nil nil nil)
-                  :body)))))
+                  :body
+                  :message)))))
 
   (testing "Empty result returns empty "
     (with-redefs-fn {#'db/get-pipelines (fn [_ filter]
                                           nil)}
       #(is (= []
               (-> @(get-pipelines "dev" "test" nil)
-                  :body)))))
+                  :body
+                  :message)))))
 
   (testing "Test filters created correctly"
     (with-redefs-fn {#'db/get-pipelines (fn [_ filter-map]


### PR DESCRIPTION
During my work on https://github.com/bob-cd/wendy/issues/10
I determined a supposable bug in the API of Bob. It does not
return a response consistent with the other list endpoints.
The fix is to use the same response function from the util
namespace.

- Fixes #73
- Relates to https://github.com/bob-cd/wendy/issues/10
- Unfortunately it breaks the API to get into a consistent state