### PR TITLE
Improved Bobs configuration (#34)

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,17 +28,42 @@ See the Kanban [board](https://github.com/bob-cd/bob/projects/1) to see the road
 ## Configuration
 Configuration uses the [environ library](https://github.com/weavejester/environ) and therefore several variables can be
 set by specifying them as environment variable or as java system property. Possible variables are:
-| java system properties | environment variables | defaults                    |
-|------------------------|-----------------------|-----------------------------|
-| bob-db-host            | BOB_DB_HOST           | localhost                   |
-| bob-db-port            | BOB_DB_PORT           | 5432                        |
-| bob-db-user            | BOB_DB_USER           | bob                         |
-| bob-db-name            | BOB_DB_NAME           | bob                         |
-| bob-docker-uri         | BOB_DOCKER_URI        | unix:///var/run/docker.sock |
-| bob-connect-timeout    | BOB_CONNECT_TIMEOUT   | 1000ms                      |
-| bob-read-timeout       | BOB_READ_TIMEOUT      | 30000ms                     |
-| bob-write-timeout      | BOB_WRITE_TIMEOUT     | 30000ms                     |
-| bob-call-timeout       | BOB_CALL_TIMEOUT      | 40000ms                     |
+| java system properties     | environment variables      | defaults                    |
+|----------------------------|----------------------------|-----------------------------|
+| bob-server-port            | BOB_SERVER_PORT            | 7777                        |
+| bob-postgres-host          | BOB_POSTGRES_HOST          | localhost                   |
+| bob-postgres-port          | BOB_POSTGRES_PORT          | 5432                        |
+| bob-postgres-user          | BOB_POSTGRES_USER          | bob                         |
+| bob-postgres-database      | BOB_POSTGRES_DATABASE      | bob                         |
+| bob-docker-uri             | BOB_DOCKER_URI             | unix:///var/run/docker.sock |
+| bob-docker-connect-timeout | BOB_DOCKER_CONNECT_TIMEOUT | 1000ms                      |
+| bob-docker-read-timeout    | BOB_DOCKER_READ_TIMEOUT    | 30000ms                     |
+| bob-docker-write-timeout   | BOB_DOCKER_WRITE_TIMEOUT   | 30000ms                     |
+| bob-docker-call-timeout    | BOB_DOCKER_CALL_TIMEOUT    | 40000ms                     |
+
+You can also set configuration in a file called `.bob.conf` inside your home folder. This is supposed to be an edn-file
+and will be merged with the config passed as env-vars, system properties and the defaults.
+
+A sample configuration looks like this:
+```
+{:server {:port 7777}
+ :docker {:uri "unix:///var/run/docker.sock",
+          :timeouts {:connect-timeout 1000,
+                     :read-timeout 30000,
+                     :write-timeout 30000,
+                     :call-timeout 40000}},
+ :postgres {:host "localhost",
+            :port 5432,
+            :user "bob",
+            :database "bob"}}
+```
+
+The priority of your configuration is following:
+
+1. defaults
+1. Environment variables
+1. Java system properties
+1. Bob's configuration file
 
 ## Testing, building and running locally
 - Clone this repository.

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -54,14 +54,7 @@ services:
       - resource-git
       - artifact-local
     environment:
-      - BOB_DB_HOST=db
-      - BOB_DB_PORT=5432
-      - BOB_DB_USER=bob
-      - BOB_DB_NAME=bob
-      - BOB_CONNECT_TIMEOUT=0
-      - BOB_READ_TIMEOUT=0
-      - BOB_WRITE_TIMEOUT=0
-      - BOB_CALL_TIMEOUT=0
+      - BOB_POSTGRES_HOST=db
     expose:
       - "7777"
     networks:

--- a/integration-tests/docker-compose.yaml
+++ b/integration-tests/docker-compose.yaml
@@ -55,14 +55,7 @@ services:
     depends_on:
       - db
     environment:
-      - BOB_DB_HOST=db
-      - BOB_DB_PORT=5432
-      - BOB_DB_USER=bob
-      - BOB_DB_NAME=bob
-      - BOB_CONNECT_TIMEOUT=0
-      - BOB_READ_TIMEOUT=0
-      - BOB_WRITE_TIMEOUT=0
-      - BOB_CALL_TIMEOUT=0
+      - BOB_POSTGRES_HOST=db
     expose:
       - "7777"
     networks:

--- a/src/bob/api/schemas.clj
+++ b/src/bob/api/schemas.clj
@@ -17,6 +17,23 @@
   (:require [schema.core :as s])
   (:import (clojure.lang Keyword)))
 
+(s/defschema ServerConfig {(s/optional-key :port) s/Int})
+
+(s/defschema DockerConfig {:uri String
+                           (s/optional-key :timeouts) {:connect-timeout s/Int
+                                                       :read-timeout    s/Int
+                                                       :write-timeout   s/Int
+                                                       :call-timeout    s/Int}})
+
+(s/defschema PostgresConfig {:host String
+                             :port s/Int
+                             :user String
+                             :database String})
+
+(s/defschema Config {(s/optional-key :server) ServerConfig
+                     :docker DockerConfig
+                     :postgres PostgresConfig})
+
 (s/defschema SimpleResponse {:message String})
 
 (s/defschema SupportedResourceTypes (s/enum "external"))
@@ -58,6 +75,17 @@
                                                :url  String}]})
 
 (comment
+  (s/validate Config {:server {:port 7777}
+                      :docker {:uri "unix:///var/run/docker.sock",
+                               :timeouts {:connect-timeout 1000,
+                                          :read-timeout 30000,
+                                          :write-timeout 30000,
+                                          :call-timeout 40000}},
+                      :postgres {:host "localhost",
+                                 :port 5432,
+                                 :user "bob",
+                                 :database "bob"}})
+
   (s/validate Step
               {:cmd               "echo hello"
                :needs_resource    "src"

--- a/src/bob/config.clj
+++ b/src/bob/config.clj
@@ -1,0 +1,78 @@
+;   This file is part of Bob.
+;
+;   Bob is free software: you can redistribute it and/or modify
+;   it under the terms of the GNU Affero General Public License as published by
+;   the Free Software Foundation, either version 3 of the License, or
+;   (at your option) any later version.
+;
+;   Bob is distributed in the hope that it will be useful,
+;   but WITHOUT ANY WARRANTY; without even the implied warranty of
+;   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+;   GNU Affero General Public License for more details.
+;
+;   You should have received a copy of the GNU Affero General Public License
+;   along with Bob. If not, see <http://www.gnu.org/licenses/>.
+
+(ns bob.config
+  (:require [clojure.edn :as edn]
+            [environ.core :as env :refer [env]]
+            [schema.core :as s]
+            [taoensso.timbre :as log]
+            [bob.api.schemas :as schema]))
+
+(defn int-from-env
+  [key default]
+  (try
+    (Integer/parseInt (get env key (str default)))
+    (catch Exception _ default)))
+
+(defn read-config-file
+  "read config from .bob.conf"
+  []
+  (let [path (str (System/getProperty "user.home") (java.io.File/separator) ".bob.conf")]
+    (try
+      (when-let [conf (clojure.java.io/file path)]
+        (when (.exists conf)
+          (edn/read-string (slurp conf))))
+      (catch Exception e
+        (log/warnf "Failed to parse %s: %s" path e)))))
+
+(defn merge-configs
+  "Merging two configs"
+  [confa confb]
+  (try
+    (merge-with merge confa confb)
+    (catch Exception e
+      (log/errorf "There was a problem with the format of your configuration file: %s" e)
+      confa)))
+
+(defn load-config
+  "Loading the config from Java System Properties and Environment
+   and merging them with .bob.conf"
+  []
+  (let [config-from-env  {:server   {:port           (int-from-env :bob-server-port 7777)}
+                          :docker   {:uri            (:bob-docker-uri env "unix:///var/run/docker.sock")
+                                     :timeouts       {:connect-timeout (int-from-env :bob-docker-connect-timeout 1000)
+                                                      :read-timeout    (int-from-env :bob-docker-read-timeout 30000)
+                                                      :write-timeout   (int-from-env :bob-docker-write-timeout 30000)
+                                                      :call-timeout    (int-from-env :bob-docker-call-timeout 40000)}}
+                          :postgres {:host           (:bob-postgres-host env "localhost")
+                                     :port           (int-from-env :bob-postgres-port 5432)
+                                     :user           (:bob-postgres-user env "bob")
+                                     :database       (:bob-postgres-database env "bob")}}
+        config-from-file (read-config-file)
+        merged-config    (merge-configs config-from-env config-from-file)]
+    (do (s/validate schema/Config merged-config)
+        (log/debugf "Config loaded: %s" merged-config)
+        merged-config)))
+
+(defonce
+  ^{:doc "Variable holding the current configuration."}
+  config (load-config))
+
+(comment
+  (load-config)
+  (alter-var-root #'config (fn [_] (load-config)))
+  (read-config-file)
+  (merge-configs {:server {:port 7777} :docker {:uri "unix:///var/run/docker.sock", :timeouts {:connect-timeout 1000, :read-timeout 30000, :write-timeout 30000, :call-timeout 40000}}, :postgres {:host "localhost", :port 5432, :user "bob", :database "bob", :ssl nil, :sslfactory nil}} (read-config-file))
+  (get-in (load-config) [:docker :uri]))

--- a/src/bob/main.clj
+++ b/src/bob/main.clj
@@ -19,16 +19,17 @@
             [clojure.repl :as repl]
             [taoensso.timbre :as log]
             [bob.states :refer :all]
+            [bob.config :refer [config]]
             [bob.api.health :as health]
             [bob.api.routes :as routes])
   (:gen-class))
 
-(def PORT 7777)
+(defonce options (:server config))
 
 ;; TODO: These states are here to avoid a cyclic import, figure out a better way.
 (m/defstate server
-  :start (do (log/infof "Bob's listening on http://0.0.0.0:%d/" PORT)
-             (http/start-server routes/bob-api {:port PORT}))
+  :start (do (log/infof "Bob's listening on http://0.0.0.0:%d/" (:port options))
+             (http/start-server routes/bob-api options))
   :stop  (do (log/info "Stopping HTTP")
              (.close server)))
 
@@ -49,3 +50,6 @@
   [& _]
   (repl/set-break-handler! shutdown!)
   (m/start))
+
+(comment
+  (alter-var-root #'options (fn [_] (:server (bob.config/load-config)))))

--- a/src/bob/pipeline/internals.clj
+++ b/src/bob/pipeline/internals.clj
@@ -20,6 +20,7 @@
             [cheshire.core :as json]
             [mount.core :as m]
             [bob.util :as u]
+            [bob.config :refer [config]]
             [bob.states :as states]
             [bob.artifact.core :as artifact]
             [bob.execution.internals :as e]
@@ -333,10 +334,10 @@
 
 (m/defstate pipeline-status-change-connection
   :start (let [datasource    (doto (PGDataSource.)
-                               (.setServerName states/db-host)
-                               (.setPort states/db-port)
-                               (.setDatabaseName states/db-name)
-                               (.setUser states/db-user))
+                               (.setServerName (get-in config [:postgres :host]))
+                               (.setPort (get-in config [:postgres :port]))
+                               (.setDatabaseName (get-in config [:postgres :database]))
+                               (.setUser (get-in config [:postgres :user])))
                stop-listener (listen-on "stopped" stop-pipeline)
                connection    (doto ^PGConnection (.getConnection datasource)
                                (.addNotificationListener stop-listener))]

--- a/src/bob/states.clj
+++ b/src/bob/states.clj
@@ -20,30 +20,11 @@
             [hikari-cp.core :as h]
             [clj-docker-client.core :as docker]
             [environ.core :as env]
-            [taoensso.timbre :as log]))
+            [taoensso.timbre :as log]
+            [bob.config :refer [config]]))
 
-(defn int-from-env
-  [key default]
-  (try
-    (Integer/parseInt (get env/env key (str default)))
-    (catch Exception _ default)))
-
-(defonce db-host (get env/env :bob-db-host "localhost"))
-(defonce db-port (int-from-env :bob-db-port 5432))
-(defonce db-user (get env/env :bob-db-user "bob"))
-(defonce db-name (get env/env :bob-db-name "bob"))
-
-(defonce docker-uri (get env/env :bob-docker-uri "unix:///var/run/docker.sock"))
-(defonce connect-timeout (int-from-env :bob-connect-timeout 1000))
-(defonce read-timeout (int-from-env :bob-read-timeout 30000))
-(defonce write-timeout (int-from-env :bob-write-timeout 30000))
-(defonce call-timeout (int-from-env :bob-call-timeout 40000))
-
-(defonce conn {:uri docker-uri
-               :timeouts {:connect-timeout connect-timeout
-                          :read-timeout    read-timeout
-                          :write-timeout   write-timeout
-                          :call-timeout    call-timeout}})
+(defonce conn (:docker config))
+(defonce postgres (:postgres config))
 
 (defonce images (docker/client {:category :images :conn conn}))
 (defonce containers (docker/client {:category :containers :conn conn}))
@@ -51,10 +32,10 @@
 
 (m/defstate data-source
   :start (let [data-source (h/make-datasource {:adapter            "postgresql"
-                                               :username           db-user
-                                               :database-name      db-name
-                                               :server-name        db-host
-                                               :port-number        db-port
+                                               :username           (:user postgres)
+                                               :database-name      (:database postgres)
+                                               :server-name        (:host postgres)
+                                               :port-number        (:port postgres)
                                                :connection-timeout 5000})]
            (defonce db {:datasource data-source})
            data-source)
@@ -63,10 +44,10 @@
 
 (m/defstate migration-config
   :start {:datastore  (jdbc/sql-database {:connection-uri (format "jdbc:postgresql://%s:%d/%s?user=%s"
-                                                                  db-host
-                                                                  db-port
-                                                                  db-name
-                                                                  db-user)})
+                                                                  (:host postgres)
+                                                                  (:port postgres)
+                                                                  (:database postgres)
+                                                                  (:user postgres))})
           :migrations (jdbc/load-resources "migrations")})
 
 (m/defstate database

--- a/test/bob/config_test.clj
+++ b/test/bob/config_test.clj
@@ -1,0 +1,78 @@
+;   This file is part of Bob.
+;
+;   Bob is free software: you can redistribute it and/or modify
+;   it under the terms of the GNU Affero General Public License as published by
+;   the Free Software Foundation, either version 3 of the License, or
+;   (at your option) any later version.
+;
+;   Bob is distributed in the hope that it will be useful,
+;   but WITHOUT ANY WARRANTY; without even the implied warranty of
+;   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+;   GNU Affero General Public License for more details.
+;
+;   You should have received a copy of the GNU Affero General Public License
+;   along with Bob. If not, see <http://www.gnu.org/licenses/>.
+
+(ns bob.config-test
+  (:require [clojure.test :refer :all]
+            [bob.test-utils :as tu]
+            [bob.config :refer :all]))
+
+(deftest load-config-test
+  (testing "defaults only"
+    (with-redefs-fn {#'read-config-file (constantly nil)}
+      #(is (= {:server {:port 7777}
+               :docker
+               {:uri "unix:///var/run/docker.sock",
+                :timeouts {:connect-timeout 1000,
+                           :read-timeout 30000,
+                           :write-timeout 30000,
+                           :call-timeout 40000}},
+               :postgres {:host "localhost",
+                          :port 5432,
+                          :user "bob",
+                          :database "bob"}}
+              (load-config)))))
+  (testing "defaults and bob.conf"
+    (with-redefs-fn {#'read-config-file (constantly {:server {:port 8888}
+                                                     :docker {:uri "foobar"}
+                                                     :postgres {:port 2345}})}
+      #(is (= {:server {:port 8888}
+               :docker
+               {:uri "foobar",
+                :timeouts {:connect-timeout 1000,
+                           :read-timeout 30000,
+                           :write-timeout 30000,
+                           :call-timeout 40000}},
+               :postgres {:host "localhost",
+                          :port 2345,
+                          :user "bob",
+                          :database "bob",}}
+              (load-config))))))
+
+(deftest merge-configs-test
+  (testing "correct merge of two overlapping configs"
+    (with-redefs-fn {#'read-config-file (constantly nil)}
+      #(is (= {:foo {:bar :baz :faz :quo}}
+             (merge-configs {:foo {:bar :baz}}
+                            {:foo {:faz :quo}})))))
+  (testing "merging of nil from bob.conf"
+    (with-redefs-fn {#'read-config-file (constantly nil)}
+      #(is (= {:foo {:bar :baz}}
+             (merge-configs {:foo {:bar :baz}}
+                            nil)))))
+  (testing "merging of deeply nested confs"
+    (with-redefs-fn {#'read-config-file (constantly nil)}
+      #(is (= {:foo {:bar {:baz {:quo "meh" :lah "ber"}}}}
+             (merge-configs {:foo {:bar {:baz {:quo "foo" :lah "ber" :yfo "cre"}}}}
+                            {:foo {:bar {:baz {:quo "meh" :lah "ber"}}}})))))
+  (testing "catched exception when merging a string"
+    (with-redefs-fn {#'read-config-file (constantly nil)}
+      #(is (= {:foo "foo" :bar {:baz "baz"}}
+             (merge-configs {:foo "foo" :bar {:baz "baz"}}
+                            "not so good file content")))))
+  (testing "catched exception when merging a vector"
+    (with-redefs-fn {#'read-config-file (constantly nil)}
+      #(is (= {:foo "foo" :bar {:baz "baz"}}
+             (merge-configs {:foo "foo" :bar {:baz "baz"}}
+                            [:meh]))))))


### PR DESCRIPTION
Bobs configuration now is validated by schema and has its own
namespace. All configuration is stored in a config variable
that is accessible and only written to at startup. People can
now use a .bob.conf to configure Bob with an edn-file.

The file is merged last so all configuration written in the
configuration file overwrites the other configurations. The
documentation is adapted to show how to write this file. When
a file is provided but cannot be parsed or merged it does
not affect the use of the other configuration parameters.

- Closes #34