### PR TITLE
Add type for better querying

### DIFF
--- a/entities/src/entities/artifact_store/core.clj
+++ b/entities/src/entities/artifact_store/core.clj
@@ -26,6 +26,7 @@
                  (crux/submit-tx db-client
                                  [[:crux.tx/put
                                    {:crux.db/id (keyword (str "bob.artifact-store/" (:name data)))
+                                    :type       :artifact-store
                                     :url        (:url data)}]]))]
     (if (f/failed? result)
       (err/publish-error queue-chan (format "Could not register artifact store: %s" (f/message result)))

--- a/entities/src/entities/pipeline/core.clj
+++ b/entities/src/entities/pipeline/core.clj
@@ -40,7 +40,8 @@
                                 (:name pipeline)))
         data   (-> pipeline
                    (dissoc :group :name)
-                   (assoc :crux.db/id id))
+                   (assoc :crux.db/id id)
+                   (assoc :type :pipeline))
         result (f/try*
                  (crux/submit-tx db-client [[:crux.tx/put data]]))]
     (if (f/failed? result)
@@ -59,6 +60,7 @@
     "Ok"))
 
 (comment
+  (def client (crux/new-api-client "http://localhost:7778"))
   (let [client (crux/new-api-client "http://localhost:7778")]
     (create client
             nil

--- a/entities/src/entities/resource_provider/core.clj
+++ b/entities/src/entities/resource_provider/core.clj
@@ -26,6 +26,7 @@
                  (crux/submit-tx db-client
                                  [[:crux.tx/put
                                    {:crux.db/id (keyword (str "bob.resource-provider/" (:name data)))
+                                    :type       :resource-provider
                                     :url        (:url data)}]]))]
     (if (f/failed? result)
       (err/publish-error queue-chan (format "Could not register resource provider: %s" (f/message result)))

--- a/entities/test/entities/artifact_store/core_test.clj
+++ b/entities/test/entities/artifact_store/core_test.clj
@@ -31,6 +31,7 @@
                            effect         (crux/entity (crux/db db) :bob.artifact-store/s3)]
                        (is (= "Ok" create-res))
                        (is (= {:crux.db/id :bob.artifact-store/s3
+                               :type       :artifact-store
                                :url        "my.store.com"}
                               effect))))))
   (testing "deletion"

--- a/entities/test/entities/pipeline/core_test.clj
+++ b/entities/test/entities/pipeline/core_test.clj
@@ -53,6 +53,7 @@
           (is (= "Ok" create-res))
           (is (= (-> pipeline
                      (dissoc :group :name)
+                     (assoc :type :pipeline)
                      (assoc :crux.db/id :bob.pipeline.test/test))
                  effect))))))
   (testing "deletion"

--- a/entities/test/entities/resource_provider/core_test.clj
+++ b/entities/test/entities/resource_provider/core_test.clj
@@ -32,6 +32,7 @@
               effect            (crux/entity (crux/db db) :bob.resource-provider/github)]
           (is (= "Ok" create-res))
           (is (= {:crux.db/id :bob.resource-provider/github
+                  :type       :resource-provider
                   :url        "my.resource.com"}
                  effect))))))
   (testing "deletion"


### PR DESCRIPTION
I did add type for better querying
```
{:find [p]
 :where [[p :type :artifact-store]]}
```
did not know how to query it for listing artifact-stores or resource-providers otherwise. Though it would be able to query for all the entities and compute them in the client but that does not make sense so I propose this change.