### PR TITLE
Fix typo in OpenAPI Spec

### DIFF
--- a/apiserver/resources/bob/api.yaml
+++ b/apiserver/resources/bob/api.yaml
@@ -1261,7 +1261,8 @@ components:
       required:
         - message
       properties:
-        $ref: "#/components/schemas/SimpleResponse"
+        schema:
+          $ref: "#/components/schemas/SimpleResponse"
 
     ResourceProvidersResponse:
       type: object


### PR DESCRIPTION
This fixes an invalid definition of the StatusResponse type.

I noticed that the OpenAPI spec wasn't quite valid.

Putting the original URL (https://raw.githubusercontent.com/bob-cd/bob/refs/heads/main/apiserver/resources/bob/api.yaml) into the Swagger editor https://editor.swagger.io/  was showing an error.

<img width="797" alt="image" src="https://github.com/user-attachments/assets/a5b19662-0d37-432f-b1be-6f5eafefaeff">

This PR fixes the error and it now shows up fine.